### PR TITLE
Add a featured field to posts and events frontmatter

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -57,6 +57,11 @@ prose:
           label: "Published"
           element: "checkbox"
           value: "true"
+      - name: "featured"
+        field:
+          label: "Featured"
+          element: "checkbox"
+          value: "false"
       - name: "title"
         field:
           label: "Title"


### PR DESCRIPTION
The field is false by default and can be turned on on the prose.io
editor by clicking the metadata button and ticking the Featured
checkbox.