### PR TITLE
Add an eventdate field to events

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -51,6 +51,13 @@ prose:
           label: "Slug"
           element: "text"
           value: "an-awesome-headline"
+      - name: "eventdate"
+        field:
+          label: "Event date"
+          element: "text"
+          help: "The date of the event"
+          value: CURRENT_DATETIME
+          type: "datetime"
     summaries:
       - name: "published"
         field:


### PR DESCRIPTION
The `eventdate` field will be used to select upcoming events to be
displayed in the homepage of ShineYourEye.

A date field can be added with the `type: “datetime”`. If you don’t add anything else you will get an empty field to fill in. You could add a `placeholder: “YYYY-MM-DD HH:MM”` with the format you want and then that placeholder text would be shown. However I think the best solution is to add `value: CURRENT_DATETIME` which is very convenient and can be parsed with `Date.parse()`. 

(None of this alone is enough to save the date in the right format, since nothing can prevent us from anybody typing anything, and it will be saved with no warning. But I think it is good enough).

This prose config:

```yaml
    events:
      - name: "eventdate"
        field:
          label: "Event date"
          element: "text"
          help: "The date of the event"
          value: CURRENT_DATETIME
          type: "datetime"
```

Produces an **Event Date** form field in the GUI:

![prose](https://cloud.githubusercontent.com/assets/2157089/22153573/cda50a46-df1f-11e6-875c-6e826192b889.png)

Which generates the following frontmatter:

```yaml
---
published: true
slug: an-awesome-headline
eventdate: '2017-01-19 20:43 +0000'
title: An Event
---
## A New Post
```
