### PR TITLE
Add published field to summaries in the prose config file

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -64,3 +64,8 @@ prose:
           label: "Featured"
           element: "checkbox"
           value: false
+      - name: "published"
+        field:
+          label: "Published"
+          element: "checkbox"
+          value: true


### PR DESCRIPTION
I just found out that the `published` field was missing in the prose config file, yet all the summary documents have a `published` field in their frontmatter.