### PR TITLE
Fix ndash which had the wrong character encoding

### DIFF
--- a/summaries/0de9e40b-52bc-459f-978b-2aea514eec79.md
+++ b/summaries/0de9e40b-52bc-459f-978b-2aea514eec79.md
@@ -2,12 +2,12 @@
 featured: false
 published: true
 ---
-Target Achievement(s): 
+Target Achievement(s):
 Through collaboration with colleagues and Relevant Ministries and Departments
 
-Legistlative Interest(s): Youth Empowerment, Upliftment of Education Standard, in my Constituency  Poverty Eradication; Ensuring proper Representation for my Constituency.
+Legistlative Interest(s): Youth Empowerment, Upliftment of Education Standard, in my Constituency – Poverty Eradication; Ensuring proper Representation for my Constituency.
 
-Awards & Honours: 
+Awards & Honours:
 Best Governor, North Central; Several Awards from Organizations and Communities for touching their lives with Projects and Social Amenities.
 
 * Student at Institute of Chartered Accountants of Nigeria ICAN
@@ -16,4 +16,3 @@ Best Governor, North Central; Several Awards from Organizations and Communities 
 * Senator at Senate from May 2011 to May 2019
 * Committee Member at Water Resources Committee (Reps) until May 2015
 * Vice-Chairman at Finance Committee (Reps) until May 2015
-


### PR DESCRIPTION
In the summary for politician with EP UUID `0de9e40b-52bc-459f-978b-2aea514eec79` (Senator DARIYE JOSHUA CHIBI) a UTF-8 encoding of a Windows-1252 was submitted when adding content through the Django admin panel. Then there was an assumption that the input was ASCII, not Windows-1252, but it was valid UTF-8, albeit one that encoded a control character, so that got stored in the database.