### PR TITLE
Redeploy the site on any new push to the gh-page branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: ruby
+branches:
+  only:
+    - gh-pages
+cache: bundler
+script:
+  - git clone 'https://github.com/theyworkforyou/shineyoureye-sinatra.git'
+  # So that Travis can cache the bundle, copy Gemfile and Gemfile.lock
+  # into the top level directory before installing:
+  - cp shineyoureye-sinatra/Gemfile{,.lock} .
+  - bundle install
+  - cd shineyoureye-sinatra
+  - git show -s --oneline
+  # This is done by bin/deploy anyway, but we need the data for the tests:
+  - bin/prepare-data
+  # Check that the tests pass, just in case:
+  - bundle exec rake test && bin/deploy
+sudo: false
+rvm:
+  - 2.3.1

--- a/_prose.yml
+++ b/_prose.yml
@@ -1,7 +1,7 @@
 prose:
   rooturl: ""
   media: "media"
-  ignore: ["_prose.yml"]
+  ignore: ["_prose.yml", ".travis.yml"]
   metadata:
     posts:
       - name: "published"


### PR DESCRIPTION
When anyone updates blog posts or person summaries via prose.io, we want
to redploy the site to incorporate that new content. A simple way of
doing this, suggested by Chris Mytton (@chrismytton), is to deploy from
Travis. This commit introduces that change, but also requires some
Travis configuration:

 * In Travis's configuration for the repository, you need to set
   GITHUB_ACCESS_TOKEN with a personal access token that permits
   pushing to the theyworkforyou/shineyoureye-static repository.

 * You need to make sure you've selected the option to prevent the
   setting of that environment variable to be logged in the public
   Travis output.

 * Set the maximum concurrent Travis jobs that may be run to be 1,
   so we don't get earlier commits deploying after later ones if they're
   running slowly.
