### PR TITLE
Correct travis file so that tests are run at the right prose commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - cd shineyoureye-sinatra
   - git show -s --oneline
   # This is done by bin/deploy anyway, but we need the data for the tests:
-  - bin/prepare-data
+  - bin/prepare-data 83f720a
   # Check that the tests pass, just in case:
   - bundle exec rake test && bin/deploy
 sudo: false


### PR DESCRIPTION
The tests in the Sinatra repo are running in Travis against a
specific commit of the prose repo. Hence, if we want the tests
to pass in this repository, they should be running against the
same commit.

See for example Travis failing for the last commit:
https://travis-ci.org/theyworkforyou/shineyoureye-prose/builds/209403240