### PR TITLE
Email the ShineYourEye deployment alias on any build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 branches:
   only:
     - gh-pages
+notifications:
+  email:
+    recipients:
+      - shineyoureye-deployment@mysociety.org
 cache: bundler
 script:
   - git clone 'https://github.com/theyworkforyou/shineyoureye-sinatra.git'


### PR DESCRIPTION
This alias will also be emailed when there's a successful build, but
that's a change in the build status.