### PR TITLE
Fix election page diverting to old site

### DIFF
--- a/info/elections.md
+++ b/info/elections.md
@@ -5,15 +5,15 @@ permalink: "/info/elections/"
 layout: page
 ---
 
-ELECTIONS | TENURE ELAPSES	| ELECTIONS DATE 
+ELECTIONS | TENURE ELAPSES	| ELECTIONS DATE
 
-------------- | -------------  | ------------- 
+------------- | -------------  | -------------
 
 Presidential Elections | May 29, 2019 | 2019
 
 National Assembly Elections | May 29, 2019 | 2019
 
-[State Government Elections](http://www.shineyoureye.org/info/state-government-elections "State Government Elections") | May 29, 2019 | 2019
+[State Government Elections](/info/state-government-elections "State Government Elections") | May 29, 2019 | 2019
 
 State Assembly Elections | May 29, 2019 | 2019
 
@@ -21,10 +21,10 @@ State Assembly Elections | May 29, 2019 | 2019
 
 []()
 
-[Local Government Elections](http://www.shineyoureye.org/info/local-government-elections "Local Government Elections")
+[Local Government Elections](/info/local-government-elections "Local Government Elections")
 
 ==================
 
-[2015 Reruns](http://www.shineyoureye.org/info/2015-reruns "2015 Reruns")
+[2015 Reruns](/info/2015-reruns "2015 Reruns")
 
 ==================


### PR DESCRIPTION
The State Government Elections, the Local Government Elections and the 2015
Reruns were all diverting to the old SYE site pages when trying to access them
from the elections page (/info/elections)

This commit makes the urls relative so that they point to the right route.

## Note for the future

The page at `info/state-government-elections` is also pointing to member pages in the old site. However, since these links are using the pombola slugs which we will use as well in the future, I decided to leave it for now. For this I have opened ticket https://github.com/theyworkforyou/shineyoureye-sinatra/issues/121

Also, this page is not linked from the main menu, although the page exists in `prose/info`. This has been ticketed in https://github.com/theyworkforyou/shineyoureye-sinatra/issues/122

## Relevant issues

Fixes https://github.com/theyworkforyou/shineyoureye-sinatra/issues/116