### PR TITLE
Remove mySociety email notifications from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: ruby
 branches:
   only:
     - gh-pages
-notifications:
-  email:
-    recipients:
-      - shineyoureye-deployment@mysociety.org
 cache: bundler
 script:
   - git clone 'https://github.com/theyworkforyou/shineyoureye-sinatra.git'


### PR DESCRIPTION
There's no longer any need to send email notifications on Travis builds to this mySociety address.